### PR TITLE
Rails 6

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -26,7 +26,7 @@ if foundation
   gem 'jquery-rails', '~> 4.3', '>= 4.3.3'
   gem 'foundation-rails'
   gem 'autoprefixer-rails'
-  gem 'sass-rails', '~> 5.0'
+  gem 'sass-rails', '~> 6.0'
 end
 
 gem 'haml-rails'

--- a/template.rb
+++ b/template.rb
@@ -26,7 +26,6 @@ if foundation
   gem 'jquery-rails', '~> 4.3', '>= 4.3.3'
   gem 'foundation-rails'
   gem 'autoprefixer-rails'
-  gem 'sass-rails', '~> 6.0'
 end
 
 gem 'haml-rails'


### PR DESCRIPTION
- remove `sass-rails` which install by default
- tested we can generate `rails-6`.